### PR TITLE
Add iburst parameter to ntp class

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,8 +1,12 @@
 class ntp::config (
-  $servers = undef
+  $servers = undef,
+  $iburst = undef,
 ) {
   if $servers == undef {
     fail('ntp::config servers parameter must be supplied')
+  }
+  if $iburst == undef {
+    fail('ntp::config iburst parameter must be supplied')
   }
   # defaults
   File {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,6 @@
 class ntp (
   $servers   = undef,
+  $iburst    = undef,
   $country   = undef,
   $continent = undef
 ) {
@@ -16,6 +17,12 @@ class ntp (
     }
   }
 
+  if $iburst {
+    $_iburst = ' iburst'
+  }
+  else {
+    $_iburst = ''
+  }
   if $servers {
     $_serverlist = $servers
   }
@@ -42,7 +49,8 @@ class ntp (
   }
 
   class { 'ntp::config':
-    servers => $_serverlist
+    servers => $_serverlist,
+    iburst => $_iburst,
   }
   include ntp::install
   include ntp::service

--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -11,7 +11,7 @@ restrict -6 default kod nomodify notrap nopeer noquery
 # Permit all access over the loopback interface.  This could
 # be tightened as well, but to do so would effect some of
 # the administrative functions.
-restrict 127.0.0.1 
+restrict 127.0.0.1
 restrict -6 ::1
 
 # Hosts on local network are less restricted.
@@ -20,7 +20,7 @@ restrict -6 ::1
 # Use public servers from the pool.ntp.org project.
 # Please consider joining the pool (http://www.pool.ntp.org/join.html).
 <% (scope.lookupvar('ntp::config::servers')).each do |entry| -%>
-server <%= entry %>
+server <%= entry %><%= iburst %>
 <% end -%>
 
 #broadcast 192.168.1.255 autokey	# broadcast server
@@ -31,9 +31,9 @@ server <%= entry %>
 #manycastclient 239.255.254.254 autokey # manycast client
 
 # Undisciplined Local Clock. This is a fake driver intended for backup
-# and when no outside source of synchronized time is available. 
+# and when no outside source of synchronized time is available.
 #server	127.127.1.0	# local clock
-#fudge	127.127.1.0 stratum 10	
+#fudge	127.127.1.0 stratum 10
 
 # Enable public key cryptography.
 #crypto
@@ -41,7 +41,7 @@ server <%= entry %>
 includefile /etc/ntp/crypto/pw
 
 # Key file containing the keys and key identifiers used when operating
-# with symmetric key cryptography. 
+# with symmetric key cryptography.
 keys /etc/ntp/keys
 
 # Specify the key identifiers which are trusted.


### PR DESCRIPTION
I used your puppet-ntp module to manage the ntp configuration on a server that was using the iburst mode in ntp.conf.  I added a parameter to control the addition of the iburst mode flag so that clients could choose to include it or not.

From man page:

"Most applications will probably want to specify the iburst option with the server command. With this option a volley of messages is exchanged to groom the data and set the clock in about ten seconds."

c.f. http://www.eecis.udel.edu/~mills/ntp/html/ntpd.html
