### PR TITLE
Updating variables in template to Ruby instance variables to prevent warnings

### DIFF
--- a/templates/changes.erb
+++ b/templates/changes.erb
@@ -1,7 +1,7 @@
 rm /files/etc/ntp.conf/server
-<% servers.each do |server| -%>
+<% @servers.each do |server| -%>
 set /files/etc/ntp.conf/server[last()+1] <%= server %>
-<% if iburst -%>
+<% if @iburst -%>
 clear /files/etc/ntp.conf/server[. = '<%= server %>']/iburst
 <% end -%>
 <% end -%>


### PR DESCRIPTION
Updating variables in template to Ruby instance variables to prevent warnings
